### PR TITLE
Fix compatibility with qiskit-machine-learning by pinning qiskit to version 1.0

### DIFF
--- a/Chapter 4/requirements.txt
+++ b/Chapter 4/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+scikit-learn
+jupyter
+qiskit-machine-learning
+matplotlib
+pylatexenc
+qiskit==1.0


### PR DESCRIPTION
---

### **Pull Request Summary**  

After installing the `qiskit-machine-learning` library, it defaults to installing `qiskit==2.0`. However, the codebase has not been updated to support this version, leading to an import error when using:  

```python
from qiskit_machine_learning.kernels import FidelityStatevectorKernel
```  

To prevent the following error:  
```
ImportError: cannot import name 'Sampler' from 'qiskit.primitives'
```
I have updated the requirements to explicitly depend on `qiskit==1.0`, ensuring compatibility and avoiding runtime issues.  